### PR TITLE
Add `connect_by_uuid` and `disconnect_by_uuid` functions

### DIFF
--- a/nmrs/src/api/models/config.rs
+++ b/nmrs/src/api/models/config.rs
@@ -202,3 +202,34 @@ impl ConnectionOptions {
         self
     }
 }
+
+/// Connection options for activating a connection by UUID
+///
+/// Allows the connection interface to be overridden
+///
+/// # Examples
+///
+/// ```rust
+/// use nmrs::ConnectByUuidConfig;
+///
+/// // Use the interface stored in the connection
+/// let config = ConnectByUuidConfig::default();
+///
+/// // Override the interface
+/// let config = ConnectByUuidConfig::default()
+///     .with_interface("wlan0");
+/// ```
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ConnectByUuidConfig<'a> {
+    pub interface: Option<&'a str>,
+}
+
+impl<'a> ConnectByUuidConfig<'a> {
+    /// Sets the interface
+    #[must_use]
+    pub fn with_interface(mut self, interface: &'a str) -> Self {
+        self.interface = Some(interface);
+        self
+    }
+}

--- a/nmrs/src/api/models/error.rs
+++ b/nmrs/src/api/models/error.rs
@@ -276,4 +276,8 @@ pub enum ConnectionError {
         /// Why the input was invalid.
         reason: String,
     },
+
+    /// No interface was found with the given name
+    #[error("no interface named '{0}'")]
+    InterfaceNotFound(String),
 }

--- a/nmrs/src/api/network_manager.rs
+++ b/nmrs/src/api/network_manager.rs
@@ -5,7 +5,6 @@ use tokio::sync::{Mutex, oneshot, watch};
 use zbus::Connection;
 use zvariant::OwnedValue;
 
-use crate::Result;
 use crate::api::models::access_point::AccessPoint;
 use crate::api::models::snapshot::{
     saved_vpn_profiles as filter_saved_vpn_profiles,
@@ -53,6 +52,7 @@ use crate::monitoring::network as network_monitor;
 use crate::monitoring::settings as settings_monitor;
 use crate::monitoring::wifi::{current_connection_info, current_ssid};
 use crate::types::constants::device_type;
+use crate::{ConnectByUuidConfig, Result};
 
 /// High-level interface to NetworkManager over D-Bus.
 ///
@@ -632,17 +632,24 @@ impl NetworkManager {
     /// # Example
     ///
     /// ```no_run
-    /// use nmrs::NetworkManager;
+    /// use nmrs::{ConnectByUuidConfig, NetworkManager};
     ///
     /// # async fn example() -> nmrs::Result<()> {
     /// let nm = NetworkManager::new().await?;
-    /// nm.connect_by_uuid("2c3f1234-abcd-5678-ef01-234567890abc").await?;
+    /// // Use the stored interface
+    /// nm.connect_by_uuid("2c3f1234-abcd-5678-ef01-234567890abc", ConnectByUuidConfig::default()).await?;
+    /// // Override the interface
+    /// nm.connect_by_uuid("2c3f1234-abcd-5678-ef01-234567890abc", ConnectByUuidConfig::default().with_interface("wlan0")).await?;
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn connect_by_uuid(&self, uuid: &str) -> Result<()> {
+    pub async fn connect_by_uuid(
+        &self,
+        uuid: &str,
+        connect_config: ConnectByUuidConfig<'_>,
+    ) -> Result<()> {
         let _guard = self.connect_guard.lock().await;
-        connect_by_uuid(&self.conn, uuid, Some(self.timeout_config)).await
+        connect_by_uuid(&self.conn, uuid, connect_config, Some(self.timeout_config)).await
     }
 
     /// Disconnect a connection by UUID.
@@ -879,12 +886,17 @@ impl NetworkManager {
     #[deprecated(note = "Use `connect_by_uuid` instead")]
     pub async fn connect_vpn_by_uuid(&self, uuid: &str) -> Result<()> {
         let _guard = self.connect_guard.lock().await;
-        connect_by_uuid(&self.conn, uuid, Some(self.timeout_config))
-            .await
-            .map_err(|e| match e {
-                ConnectionError::SavedConnectionNotFound(id) => ConnectionError::VpnNotFound(id),
-                other => other,
-            })
+        connect_by_uuid(
+            &self.conn,
+            uuid,
+            ConnectByUuidConfig::default(),
+            Some(self.timeout_config),
+        )
+        .await
+        .map_err(|e| match e {
+            ConnectionError::SavedConnectionNotFound(id) => ConnectionError::VpnNotFound(id),
+            other => other,
+        })
     }
 
     /// Activate a saved VPN by connection display name.

--- a/nmrs/src/api/network_manager.rs
+++ b/nmrs/src/api/network_manager.rs
@@ -21,8 +21,8 @@ use crate::core::active_connection as active_connections;
 use crate::core::airplane;
 use crate::core::bluetooth::connect_bluetooth;
 use crate::core::connection::{
-    connect, connect_to_bssid, connect_wired, disconnect, forget_by_name_and_type,
-    get_device_by_interface, is_connected,
+    connect, connect_by_uuid, connect_to_bssid, connect_wired, disconnect, disconnect_by_uuid,
+    forget_by_name_and_type, get_device_by_interface, is_connected,
 };
 use crate::core::connection_settings::{
     get_saved_connection_path, get_saved_connection_uuid, has_saved_connection,
@@ -38,8 +38,8 @@ use crate::core::device::{
 use crate::core::saved_connection as saved_profiles;
 use crate::core::scan::{current_network, list_access_points, list_networks, scan_networks};
 use crate::core::vpn::{
-    active_vpn_connections, connect_vpn, connect_vpn_by_id, connect_vpn_by_uuid, disconnect_vpn,
-    disconnect_vpn_by_uuid, get_vpn_info, list_vpn_connections,
+    active_vpn_connections, connect_vpn, connect_vpn_by_id, disconnect_vpn, get_vpn_info,
+    list_vpn_connections,
 };
 use crate::core::wifi_device::{list_wifi_devices, set_wifi_enabled_for_interface};
 use crate::models::{
@@ -627,6 +627,30 @@ impl NetworkManager {
         .await
     }
 
+    /// Activate a saved connection by UUID.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use nmrs::NetworkManager;
+    ///
+    /// # async fn example() -> nmrs::Result<()> {
+    /// let nm = NetworkManager::new().await?;
+    /// nm.connect_by_uuid("2c3f1234-abcd-5678-ef01-234567890abc").await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn connect_by_uuid(&self, uuid: &str) -> Result<()> {
+        let _guard = self.connect_guard.lock().await;
+        connect_by_uuid(&self.conn, uuid, Some(self.timeout_config)).await
+    }
+
+    /// Disconnect a connection by UUID.
+    pub async fn disconnect_by_uuid(&self, uuid: &str) -> Result<()> {
+        let _guard = self.connect_guard.lock().await;
+        disconnect_by_uuid(&self.conn, uuid).await
+    }
+
     /// Connects to a wired (Ethernet) device.
     ///
     /// Finds the first available wired device and either activates an existing
@@ -852,9 +876,15 @@ impl NetworkManager {
     /// # Ok(())
     /// # }
     /// ```
+    #[deprecated(note = "Use `connect_by_uuid` instead")]
     pub async fn connect_vpn_by_uuid(&self, uuid: &str) -> Result<()> {
         let _guard = self.connect_guard.lock().await;
-        connect_vpn_by_uuid(&self.conn, uuid, Some(self.timeout_config)).await
+        connect_by_uuid(&self.conn, uuid, Some(self.timeout_config))
+            .await
+            .map_err(|e| match e {
+                ConnectionError::SavedConnectionNotFound(id) => ConnectionError::VpnNotFound(id),
+                other => other,
+            })
     }
 
     /// Activate a saved VPN by connection display name.
@@ -867,9 +897,10 @@ impl NetworkManager {
     }
 
     /// Disconnect a VPN by UUID.
+    #[deprecated(note = "Use `disconnect_by_uuid` instead")]
     pub async fn disconnect_vpn_by_uuid(&self, uuid: &str) -> Result<()> {
         let _guard = self.connect_guard.lock().await;
-        disconnect_vpn_by_uuid(&self.conn, uuid).await
+        disconnect_by_uuid(&self.conn, uuid).await
     }
 
     /// Forgets (deletes) a saved VPN connection by name.

--- a/nmrs/src/api/network_manager.rs
+++ b/nmrs/src/api/network_manager.rs
@@ -883,7 +883,7 @@ impl NetworkManager {
     /// # Ok(())
     /// # }
     /// ```
-    #[deprecated(note = "Use `connect_by_uuid` instead")]
+    #[deprecated(since = "3.6.0", note = "Use `connect_by_uuid` instead")]
     pub async fn connect_vpn_by_uuid(&self, uuid: &str) -> Result<()> {
         let _guard = self.connect_guard.lock().await;
         connect_by_uuid(
@@ -909,7 +909,7 @@ impl NetworkManager {
     }
 
     /// Disconnect a VPN by UUID.
-    #[deprecated(note = "Use `disconnect_by_uuid` instead")]
+    #[deprecated(since = "3.6.0", note = "Use `disconnect_by_uuid` instead")]
     pub async fn disconnect_vpn_by_uuid(&self, uuid: &str) -> Result<()> {
         let _guard = self.connect_guard.lock().await;
         disconnect_by_uuid(&self.conn, uuid).await

--- a/nmrs/src/core/connection.rs
+++ b/nmrs/src/core/connection.rs
@@ -4,7 +4,6 @@ use std::collections::HashMap;
 use zbus::Connection;
 use zvariant::OwnedObjectPath;
 
-use crate::Result;
 use crate::api::builders::wifi::{build_ethernet_connection, try_build_wifi_connection};
 use crate::api::models::{ConnectionError, ConnectionOptions, TimeoutConfig, WifiSecurity};
 use crate::core::connection_settings::{delete_connection, get_saved_connection_path};
@@ -17,6 +16,7 @@ use crate::types::constants::{device_state, device_type, timeouts};
 use crate::types::device_type_registry;
 use crate::util::utils::{decode_ssid_or_empty, nm_proxy};
 use crate::util::validation::{validate_bssid, validate_ssid, validate_wifi_security};
+use crate::{ConnectByUuidConfig, Result};
 
 /// Decision on whether to reuse a saved connection or create a fresh one.
 #[derive(Debug, PartialEq, Eq)]
@@ -125,6 +125,7 @@ pub(crate) async fn connect(
 pub(crate) async fn connect_by_uuid(
     conn: &Connection,
     uuid: &str,
+    connect_config: ConnectByUuidConfig<'_>,
     timeout_config: Option<TimeoutConfig>,
 ) -> Result<()> {
     let nm = NMProxy::new(conn).await?;
@@ -143,12 +144,13 @@ pub(crate) async fn connect_by_uuid(
 
     let conn_path: OwnedObjectPath = reply.body().deserialize()?;
 
+    let device = match connect_config.interface {
+        Some(interface) => get_device_by_interface(conn, interface).await?,
+        None => OwnedObjectPath::default(),
+    };
+
     let active_conn = nm
-        .activate_connection(
-            conn_path,
-            OwnedObjectPath::default(),
-            OwnedObjectPath::default(),
-        )
+        .activate_connection(conn_path, device, OwnedObjectPath::default())
         .await?;
 
     let timeout = timeout_config.map(|c| c.connection_timeout);

--- a/nmrs/src/core/connection.rs
+++ b/nmrs/src/core/connection.rs
@@ -14,7 +14,7 @@ use crate::monitoring::transport::ActiveTransport;
 use crate::monitoring::wifi::Wifi;
 use crate::types::constants::{device_state, device_type, timeouts};
 use crate::types::device_type_registry;
-use crate::util::utils::{decode_ssid_or_empty, nm_proxy};
+use crate::util::utils::{decode_ssid_or_empty, nm_proxy, settings_proxy};
 use crate::util::validation::{validate_bssid, validate_ssid, validate_wifi_security};
 use crate::{ConnectByUuidConfig, Result};
 
@@ -130,22 +130,19 @@ pub(crate) async fn connect_by_uuid(
 ) -> Result<()> {
     let nm = NMProxy::new(conn).await?;
 
-    let settings_proxy = nm_proxy(
-        conn,
-        "/org/freedesktop/NetworkManager/Settings",
-        "org.freedesktop.NetworkManager.Settings",
-    )
-    .await?;
+    let settings_proxy = settings_proxy(conn).await?;
 
-    let reply = settings_proxy
-        .call_method("GetConnectionByUuid", &(uuid,))
-        .await
-        .map_err(|_| ConnectionError::SavedConnectionNotFound(uuid.to_string()))?;
-
-    let conn_path: OwnedObjectPath = reply.body().deserialize()?;
+    let conn_path = get_connection_path_by_uuid(&settings_proxy, uuid).await?;
 
     let device = match connect_config.interface {
-        Some(interface) => get_device_by_interface(conn, interface).await?,
+        Some(interface) => get_device_by_interface(conn, interface)
+            .await
+            .map_err(|e| match e {
+                ConnectionError::NotFound => {
+                    ConnectionError::InterfaceNotFound(interface.to_string())
+                }
+                other => other,
+            })?,
         None => OwnedObjectPath::default(),
     };
 
@@ -185,7 +182,26 @@ pub(crate) async fn disconnect_by_uuid(conn: &Connection, uuid: &str) -> Result<
         }
     }
 
-    Ok(())
+    let settings_proxy = settings_proxy(conn).await?;
+
+    get_connection_path_by_uuid(&settings_proxy, uuid)
+        .await
+        .map(|_| ())
+}
+
+/// Get the `OwnedObjectPath` of a connection by its UUID. Returns `ConnectionError::SavedConnectionNotFound` on error
+pub(crate) async fn get_connection_path_by_uuid(
+    proxy: &zbus::Proxy<'_>,
+    uuid: &str,
+) -> Result<OwnedObjectPath> {
+    let reply = proxy
+        .call_method("GetConnectionByUuid", &(uuid,))
+        .await
+        .map_err(|_| ConnectionError::SavedConnectionNotFound(uuid.to_string()))?;
+
+    let conn_path = reply.body().deserialize()?;
+
+    Ok(conn_path)
 }
 
 /// Connects to a wired (Ethernet) device.

--- a/nmrs/src/core/connection.rs
+++ b/nmrs/src/core/connection.rs
@@ -121,6 +121,71 @@ pub(crate) async fn connect(
     Ok(())
 }
 
+/// Activate a saved connection by UUID.
+pub(crate) async fn connect_by_uuid(
+    conn: &Connection,
+    uuid: &str,
+    timeout_config: Option<TimeoutConfig>,
+) -> Result<()> {
+    let nm = NMProxy::new(conn).await?;
+
+    let settings_proxy = nm_proxy(
+        conn,
+        "/org/freedesktop/NetworkManager/Settings",
+        "org.freedesktop.NetworkManager.Settings",
+    )
+    .await?;
+
+    let reply = settings_proxy
+        .call_method("GetConnectionByUuid", &(uuid,))
+        .await
+        .map_err(|_| ConnectionError::SavedConnectionNotFound(uuid.to_string()))?;
+
+    let conn_path: OwnedObjectPath = reply.body().deserialize()?;
+
+    let active_conn = nm
+        .activate_connection(
+            conn_path,
+            OwnedObjectPath::default(),
+            OwnedObjectPath::default(),
+        )
+        .await?;
+
+    let timeout = timeout_config.map(|c| c.connection_timeout);
+    wait_for_connection_activation(conn, &active_conn, timeout).await
+}
+
+/// Disconnect a connection by UUID.
+pub(crate) async fn disconnect_by_uuid(conn: &Connection, uuid: &str) -> Result<()> {
+    let nm = NMProxy::new(conn).await?;
+    let active_conns = nm.active_connections().await.unwrap_or_default();
+
+    for ac_path in active_conns {
+        let ac_proxy = match nm_proxy(
+            conn,
+            ac_path.clone(),
+            "org.freedesktop.NetworkManager.Connection.Active",
+        )
+        .await
+        {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
+
+        let ac_uuid: String = match ac_proxy.get_property("Uuid").await {
+            Ok(u) => u,
+            Err(_) => continue,
+        };
+
+        if ac_uuid == uuid {
+            nm.deactivate_connection(ac_path).await?;
+            return Ok(());
+        }
+    }
+
+    Ok(())
+}
+
 /// Connects to a wired (Ethernet) device.
 ///
 /// This is the main entry point for establishing a wired connection. The flow:

--- a/nmrs/src/core/vpn.rs
+++ b/nmrs/src/core/vpn.rs
@@ -594,15 +594,17 @@ pub(crate) async fn connect_vpn_by_id(
 
     match matches.len() {
         0 => Err(ConnectionError::VpnNotFound(id.to_string())),
-        1 => {
-            connect_by_uuid(
-                conn,
-                &matches[0].uuid,
-                ConnectByUuidConfig::default(),
-                timeout_config,
-            )
-            .await
-        }
+        1 => connect_by_uuid(
+            conn,
+            &matches[0].uuid,
+            ConnectByUuidConfig::default(),
+            timeout_config,
+        )
+        .await
+        .map_err(|e| match e {
+            ConnectionError::SavedConnectionNotFound(id) => ConnectionError::VpnNotFound(id),
+            other => other,
+        }),
         _ => Err(ConnectionError::VpnIdAmbiguous(id.to_string())),
     }
 }

--- a/nmrs/src/core/vpn.rs
+++ b/nmrs/src/core/vpn.rs
@@ -19,6 +19,7 @@ use crate::api::models::{
 };
 use crate::builders::{build_openvpn_connection, build_wireguard_connection};
 use crate::core::active_connection::is_missing_dbus_object_error;
+use crate::core::connection::connect_by_uuid;
 use crate::core::state_wait::wait_for_connection_activation;
 use crate::dbus::{NMActiveConnectionProxy, NMProxy};
 use crate::models::VpnConfiguration;
@@ -582,40 +583,6 @@ async fn build_active_vpn_map(
     map
 }
 
-/// Activate a saved VPN by UUID.
-pub(crate) async fn connect_vpn_by_uuid(
-    conn: &Connection,
-    uuid: &str,
-    timeout_config: Option<TimeoutConfig>,
-) -> Result<()> {
-    let nm = NMProxy::new(conn).await?;
-
-    let settings_proxy = nm_proxy(
-        conn,
-        "/org/freedesktop/NetworkManager/Settings",
-        "org.freedesktop.NetworkManager.Settings",
-    )
-    .await?;
-
-    let reply = settings_proxy
-        .call_method("GetConnectionByUuid", &(uuid,))
-        .await
-        .map_err(|_| ConnectionError::VpnNotFound(uuid.to_string()))?;
-
-    let conn_path: OwnedObjectPath = reply.body().deserialize()?;
-
-    let active_conn = nm
-        .activate_connection(
-            conn_path,
-            OwnedObjectPath::default(),
-            OwnedObjectPath::default(),
-        )
-        .await?;
-
-    let timeout = timeout_config.map(|c| c.connection_timeout);
-    wait_for_connection_activation(conn, &active_conn, timeout).await
-}
-
 /// Activate a saved VPN by connection id (display name).
 pub(crate) async fn connect_vpn_by_id(
     conn: &Connection,
@@ -627,40 +594,9 @@ pub(crate) async fn connect_vpn_by_id(
 
     match matches.len() {
         0 => Err(ConnectionError::VpnNotFound(id.to_string())),
-        1 => connect_vpn_by_uuid(conn, &matches[0].uuid, timeout_config).await,
+        1 => connect_by_uuid(conn, &matches[0].uuid, timeout_config).await,
         _ => Err(ConnectionError::VpnIdAmbiguous(id.to_string())),
     }
-}
-
-/// Disconnect a VPN by UUID.
-pub(crate) async fn disconnect_vpn_by_uuid(conn: &Connection, uuid: &str) -> Result<()> {
-    let nm = NMProxy::new(conn).await?;
-    let active_conns = nm.active_connections().await.unwrap_or_default();
-
-    for ac_path in active_conns {
-        let ac_proxy = match nm_proxy(
-            conn,
-            ac_path.clone(),
-            "org.freedesktop.NetworkManager.Connection.Active",
-        )
-        .await
-        {
-            Ok(p) => p,
-            Err(_) => continue,
-        };
-
-        let ac_uuid: String = match ac_proxy.get_property("Uuid").await {
-            Ok(u) => u,
-            Err(_) => continue,
-        };
-
-        if ac_uuid == uuid {
-            nm.deactivate_connection(ac_path).await?;
-            return Ok(());
-        }
-    }
-
-    Ok(())
 }
 
 /// Connects to a VPN (WireGuard or OpenVPN) from configuration.

--- a/nmrs/src/core/vpn.rs
+++ b/nmrs/src/core/vpn.rs
@@ -11,7 +11,6 @@ use std::collections::HashMap;
 use zbus::Connection;
 use zvariant::OwnedObjectPath;
 
-use crate::Result;
 use crate::api::models::{
     ConnectionError, ConnectionOptions, DeviceState, OpenVpnConnectionType, TimeoutConfig,
     VpnConfig, VpnConnection, VpnConnectionInfo, VpnCredentials, VpnDetails, VpnKind,
@@ -27,6 +26,7 @@ use crate::util::utils::{extract_connection_state_reason, nm_proxy, settings_pro
 use crate::util::validation::{
     validate_connection_name, validate_openvpn_config, validate_vpn_credentials,
 };
+use crate::{ConnectByUuidConfig, Result};
 
 /// Detects whether a saved connection is a VPN and what kind.
 fn detect_vpn_kind(
@@ -594,7 +594,15 @@ pub(crate) async fn connect_vpn_by_id(
 
     match matches.len() {
         0 => Err(ConnectionError::VpnNotFound(id.to_string())),
-        1 => connect_by_uuid(conn, &matches[0].uuid, timeout_config).await,
+        1 => {
+            connect_by_uuid(
+                conn,
+                &matches[0].uuid,
+                ConnectByUuidConfig::default(),
+                timeout_config,
+            )
+            .await
+        }
         _ => Err(ConnectionError::VpnIdAmbiguous(id.to_string())),
     }
 }

--- a/nmrs/src/lib.rs
+++ b/nmrs/src/lib.rs
@@ -439,17 +439,17 @@ pub mod models {
 pub use api::models::{
     AccessPoint, ActiveConnection, ActiveConnectionState, ActiveOtherConnection,
     ActiveVpnConnection, ActiveWifiConnection, ActiveWiredConnection, AirplaneModeState, ApMode,
-    AppletNetworkSummary, BluetoothDevice, BluetoothIdentity, BluetoothNetworkRole, ConnectType,
-    ConnectionError, ConnectionOptions, ConnectionStateReason, ConnectivityReport,
-    ConnectivityState, Device, DeviceState, DeviceType, EapMethod, EapOptions, MonitorHandle,
-    Network, NetworkEvent, NetworkEventStream, NetworkInfo, NetworkSnapshot, OpenVpnAuthType,
-    OpenVpnCompression, OpenVpnConfig, OpenVpnConnectionType, OpenVpnProxy, Phase2, RadioState,
-    SavedConnection, SavedConnectionBrief, SavedVpnSummary, SecurityFeatures, SettingsChange,
-    SettingsEventStream, SettingsPatch, SettingsSummary, StateReason, TimeoutConfig, VlanConfig,
-    VpnConfig, VpnConfiguration, VpnConnection, VpnConnectionInfo, VpnCredentials, VpnDetails,
-    VpnKind, VpnRoute, VpnSecretFlags, VpnType, WifiDevice, WifiKeyMgmt, WifiNetworkGroup,
-    WifiSecurity, WifiSecuritySummary, WireGuardConfig, WireGuardPeer, WiredDevice,
-    connection_state_reason_to_error, reason_to_error,
+    AppletNetworkSummary, BluetoothDevice, BluetoothIdentity, BluetoothNetworkRole,
+    ConnectByUuidConfig, ConnectType, ConnectionError, ConnectionOptions, ConnectionStateReason,
+    ConnectivityReport, ConnectivityState, Device, DeviceState, DeviceType, EapMethod, EapOptions,
+    MonitorHandle, Network, NetworkEvent, NetworkEventStream, NetworkInfo, NetworkSnapshot,
+    OpenVpnAuthType, OpenVpnCompression, OpenVpnConfig, OpenVpnConnectionType, OpenVpnProxy,
+    Phase2, RadioState, SavedConnection, SavedConnectionBrief, SavedVpnSummary, SecurityFeatures,
+    SettingsChange, SettingsEventStream, SettingsPatch, SettingsSummary, StateReason,
+    TimeoutConfig, VlanConfig, VpnConfig, VpnConfiguration, VpnConnection, VpnConnectionInfo,
+    VpnCredentials, VpnDetails, VpnKind, VpnRoute, VpnSecretFlags, VpnType, WifiDevice,
+    WifiKeyMgmt, WifiNetworkGroup, WifiSecurity, WifiSecuritySummary, WireGuardConfig,
+    WireGuardPeer, WiredDevice, connection_state_reason_to_error, reason_to_error,
 };
 pub use api::network_manager::NetworkManager;
 pub use api::wifi_scope::WifiScope;

--- a/nmrs/tests/integration_test.rs
+++ b/nmrs/tests/integration_test.rs
@@ -183,7 +183,13 @@ async fn cleanup_wired_profile(nm: &NetworkManager, interface: &str) -> Vec<Stri
 
 async fn cleanup_vpn_profile(nm: &NetworkManager, uuid: &str) -> Vec<String> {
     let mut failures = Vec::new();
-    match timeout(DBUS_TIMEOUT, nm.disconnect_vpn_by_uuid(uuid)).await {
+    match timeout(
+        DBUS_TIMEOUT,
+        #[allow(deprecated)]
+        nm.disconnect_vpn_by_uuid(uuid),
+    )
+    .await
+    {
         Ok(Ok(())) => {}
         Ok(Err(ConnectionError::VpnNotFound(missing))) if missing == uuid => {}
         Ok(Err(error)) => failures.push(format!("disconnect VPN {uuid}: {error}")),
@@ -657,7 +663,7 @@ async fn networkmanager_secret_agent_registration_lifecycle() {
         let missing_error = bounded(
             "reject activation of a missing VPN UUID",
             DBUS_TIMEOUT,
-            nm.connect_vpn_by_uuid(&missing_uuid),
+            #[allow(deprecated)] nm.connect_vpn_by_uuid(&missing_uuid),
         )
         .await
         .expect_err("activation of a missing VPN UUID must fail");
@@ -752,7 +758,7 @@ async fn networkmanager_secret_agent_registration_lifecycle() {
         bounded(
             "activate the configured WireGuard profile",
             WIFI_TIMEOUT,
-            nm.connect_vpn_by_uuid(&profile_uuid),
+            #[allow(deprecated)] nm.connect_vpn_by_uuid(&profile_uuid),
         )
         .await
         .expect("WireGuard activation failed after persisting the agent-provided key");
@@ -814,7 +820,7 @@ async fn networkmanager_secret_agent_registration_lifecycle() {
         bounded(
             "deactivate the WireGuard VPN",
             DBUS_TIMEOUT,
-            nm.disconnect_vpn_by_uuid(&profile_uuid),
+            #[allow(deprecated)] nm.disconnect_vpn_by_uuid(&profile_uuid),
         )
         .await
         .expect("failed to deactivate the WireGuard VPN");
@@ -1041,6 +1047,47 @@ async fn wired_connection_lifecycle() {
         )
         .await
         .expect("failed to read disconnected wired details");
+        let disconnected = disconnected_details
+            .iter()
+            .find(|device| device.interface == interface)
+            .expect("disconnected veth was absent from detailed wired devices");
+        assert_eq!(disconnected.state, DeviceState::Disconnected);
+        assert!(disconnected.active_connection_id.is_none());
+
+        bounded(
+            "connect the managed veth client by uuid",
+            DBUS_TIMEOUT,
+            nm.connect_by_uuid(&saved_uuid),
+        )
+        .await
+        .expect("activation by uuid failed");
+        let active = active_connections(&nm).await;
+        let active_wired = active
+            .iter()
+            .find_map(|connection| match connection {
+                ActiveConnection::Wired(wired) if wired.uuid == saved_uuid => Some(wired.clone()),
+                _ => None,
+            })
+            .unwrap_or_else(|| {
+                panic!("typed active connections omitted the veth connection: {active:?}")
+            });
+        assert_eq!(active_wired.state, ActiveConnectionState::Activated);
+
+        bounded(
+            "disconnect the managed veth client by uuid",
+            DBUS_TIMEOUT,
+            nm.disconnect_by_uuid(&saved_uuid),
+        )
+        .await
+        .expect("deactivation by uuid failed");
+        let disconnected_details = bounded(
+            "read disconnected wired details",
+            DBUS_TIMEOUT,
+            nm.list_wired_device_details(),
+        )
+        .await
+        .expect("failed to read disconnected wired details");
+
         let disconnected = disconnected_details
             .iter()
             .find(|device| device.interface == interface)

--- a/nmrs/tests/integration_test.rs
+++ b/nmrs/tests/integration_test.rs
@@ -10,10 +10,10 @@ use nmrs::agent::{SecretAgent, SecretAgentFlags, SecretAgentHandle, SecretSettin
 use nmrs::builders::WireGuardBuilder;
 use nmrs::raw::zvariant::{OwnedObjectPath, OwnedValue, Value};
 use nmrs::{
-    ActiveConnection, ActiveConnectionState, ConnectionError, DeviceState, MonitorHandle,
-    NetworkEvent, NetworkEventStream, NetworkManager, SettingsChange, SettingsEventStream,
-    SettingsPatch, SettingsSummary, TimeoutConfig, WifiKeyMgmt, WifiScope, WifiSecurity,
-    WireGuardPeer,
+    ActiveConnection, ActiveConnectionState, ConnectByUuidConfig, ConnectionError, DeviceState,
+    MonitorHandle, NetworkEvent, NetworkEventStream, NetworkManager, SettingsChange,
+    SettingsEventStream, SettingsPatch, SettingsSummary, TimeoutConfig, WifiKeyMgmt, WifiScope,
+    WifiSecurity, WireGuardPeer,
 };
 use serial_test::serial;
 use tokio::time::{sleep, timeout};
@@ -1057,7 +1057,7 @@ async fn wired_connection_lifecycle() {
         bounded(
             "connect the managed veth client by uuid",
             DBUS_TIMEOUT,
-            nm.connect_by_uuid(&saved_uuid),
+            nm.connect_by_uuid(&saved_uuid, ConnectByUuidConfig::default()),
         )
         .await
         .expect("activation by uuid failed");


### PR DESCRIPTION
This PR adds the `connect_by_uuid` and `disconnect_by_uuid` functions. The logic in these functions are taken from the `connect_vpn_by_uuid` and `disconnect_vpn_by_uuid` functions, which have been moved to the `connection` module. The vpn functions have been deprecated, with a note pointing to the new functions. I have also added a `ConnectByUuidConfig` struct, which allows the user to override the interface. I have updated the intergration tests to include connecting and disconnecting to the wired conenction by uuid.

Note, this does not include `connect_vpn_by_id` as that included a lot of VPN specific logic.

Closes #515 

No AI was used in creating this PR