### PR TITLE
fix(#531): keep `disconnect_vpn_by_uuid` returning `Ok(())` for unknown UUIDs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,7 +218,7 @@ jobs:
           shared-key: semver-checks
 
       - name: Check semver compatibility
-        run: cargo semver-checks check-release -p nmrs
+        run: cargo semver-checks check-release -p nmrs --release-type minor
 
   build:
     name: Build (aarch64-unknown-linux-gnu)

--- a/nmrs/CHANGELOG.md
+++ b/nmrs/CHANGELOG.md
@@ -3,6 +3,27 @@
 All notable changes to the `nmrs` crate will be documented in this file.
 
 ## [Unreleased]
+### Added
+
+- `connect_by_uuid()` and `disconnect_by_uuid()` activate and deactivate any
+  saved connection by UUID, not just VPN profiles. `connect_by_uuid()` takes a
+  `ConnectByUuidConfig` so the interface stored in the profile can be
+  overridden. ([#531](https://github.com/freedesktop-rs/nmrs/pull/531))
+
+### Deprecated
+
+- `connect_vpn_by_uuid()` and `disconnect_vpn_by_uuid()` in favour of
+  `connect_by_uuid()` and `disconnect_by_uuid()`. Neither carried VPN-specific
+  logic. Both keep their existing signatures and error behaviour, so no
+  existing code breaks. ([#531](https://github.com/freedesktop-rs/nmrs/pull/531))
+
+### Fixed
+
+- `disconnect_vpn_by_uuid()` again returns `Ok(())` when no saved connection
+  matches the UUID. Delegating to `disconnect_by_uuid()` leaked that case out
+  as `ConnectionError::SavedConnectionNotFound`, which callers of the
+  deprecated method had no reason to expect.
+  ([#531](https://github.com/freedesktop-rs/nmrs/pull/531))
 
 ## [3.5.0] - 2026-08-19
 ### Added

--- a/nmrs/src/api/network_manager.rs
+++ b/nmrs/src/api/network_manager.rs
@@ -909,10 +909,19 @@ impl NetworkManager {
     }
 
     /// Disconnect a VPN by UUID.
+    ///
+    /// Returns `Ok(())` when no saved connection matches `uuid`, preserving the
+    /// behaviour this method had before it delegated to
+    /// [`disconnect_by_uuid`](Self::disconnect_by_uuid), which reports the
+    /// missing profile as
+    /// [`SavedConnectionNotFound`](crate::ConnectionError::SavedConnectionNotFound).
     #[deprecated(since = "3.6.0", note = "Use `disconnect_by_uuid` instead")]
     pub async fn disconnect_vpn_by_uuid(&self, uuid: &str) -> Result<()> {
         let _guard = self.connect_guard.lock().await;
-        disconnect_by_uuid(&self.conn, uuid).await
+        match disconnect_by_uuid(&self.conn, uuid).await {
+            Err(ConnectionError::SavedConnectionNotFound(_)) => Ok(()),
+            other => other,
+        }
     }
 
     /// Forgets (deletes) a saved VPN connection by name.


### PR DESCRIPTION
Map the variant back to `Ok(())` in the wrapper so the deprecated method keeps its original behavior.

Also records the missing `[Unreleased]` changelog entries for #531.