### PR TITLE
fix: correct deprecated note on `connect`/`disconnect_vpn_by_uuid`

### DIFF
--- a/nmrs/CHANGELOG.md
+++ b/nmrs/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to the `nmrs` crate will be documented in this file.
 
 ## [Unreleased]
 ### Fixed
-- `#[deprecated(since = ...)]` on `connect_vpn_by_uuid()` and `disconnect_vpn_by_uuid()` said `3.6.0`; corrected to `3.5.1`, the release that actually deprecated them.
+- `#[deprecated(since = ...)]` on `connect_vpn_by_uuid()` and `disconnect_vpn_by_uuid()` said `3.6.0`; corrected to `3.5.1`, the release that actually deprecated them.([#544](https://github.com/freedesktop-rs/nmrs/pull/544))
+- `disconnect()` no longer fails with `org.freedesktop.NetworkManager.Device.NotActive` when the device finishes deactivating between the state check and the `Disconnect` call. The error is treated as already-disconnected and the call still waits for the device to settle. ([#544](https://github.com/freedesktop-rs/nmrs/pull/544))
 
 ## [3.5.1] - 2026-09-02
 ### Added

--- a/nmrs/CHANGELOG.md
+++ b/nmrs/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to the `nmrs` crate will be documented in this file.
 
 ## [Unreleased]
+### Fixed
+- `#[deprecated(since = ...)]` on `connect_vpn_by_uuid()` and `disconnect_vpn_by_uuid()` said `3.6.0`; corrected to `3.5.1`, the release that actually deprecated them.
 
 ## [3.5.1] - 2026-09-02
 ### Added

--- a/nmrs/src/api/network_manager.rs
+++ b/nmrs/src/api/network_manager.rs
@@ -883,7 +883,7 @@ impl NetworkManager {
     /// # Ok(())
     /// # }
     /// ```
-    #[deprecated(since = "3.6.0", note = "Use `connect_by_uuid` instead")]
+    #[deprecated(since = "3.5.1", note = "Use `connect_by_uuid` instead")]
     pub async fn connect_vpn_by_uuid(&self, uuid: &str) -> Result<()> {
         let _guard = self.connect_guard.lock().await;
         connect_by_uuid(
@@ -915,7 +915,7 @@ impl NetworkManager {
     /// [`disconnect_by_uuid`](Self::disconnect_by_uuid), which reports the
     /// missing profile as
     /// [`SavedConnectionNotFound`](crate::ConnectionError::SavedConnectionNotFound).
-    #[deprecated(since = "3.6.0", note = "Use `disconnect_by_uuid` instead")]
+    #[deprecated(since = "3.5.1", note = "Use `disconnect_by_uuid` instead")]
     pub async fn disconnect_vpn_by_uuid(&self, uuid: &str) -> Result<()> {
         let _guard = self.connect_guard.lock().await;
         match disconnect_by_uuid(&self.conn, uuid).await {

--- a/nmrs/src/core/connection.rs
+++ b/nmrs/src/core/connection.rs
@@ -537,8 +537,19 @@ pub(crate) async fn disconnect_wifi_and_wait(
     .await?;
 
     trace!("Sending disconnect request");
-    raw.call_method("Disconnect", &()).await?;
-    trace!("Disconnect method called successfully");
+    match raw.call_method("Disconnect", &()).await {
+        Ok(_) => trace!("Disconnect method called successfully"),
+        // The device can finish deactivating between the state check above
+        // and this call (e.g. after `DeactivateConnection`), in which case
+        // NetworkManager rejects `Disconnect` with `Device.NotActive`. That
+        // is the outcome we want, so fall through to the state wait.
+        Err(zbus::Error::MethodError(name, _, _))
+            if name.as_str() == "org.freedesktop.NetworkManager.Device.NotActive" =>
+        {
+            debug!("Device already inactive when Disconnect was called");
+        }
+        Err(e) => return Err(e.into()),
+    }
 
     // Wait for disconnect using signal-based monitoring
     let timeout = timeout_config.map(|c| c.disconnect_timeout);

--- a/nmrs/tests/integration_test.rs
+++ b/nmrs/tests/integration_test.rs
@@ -1540,13 +1540,21 @@ async fn wifi_wpa_saved_connection_lifecycle() {
         )
         .await
         .expect("failed to re-enable WiFi after the network-monitor contract");
+        // After an rfkill cycle the device object may be destroyed and
+        // re-created at a new path; retry until NM settles.
         bounded(
             "wait for WiFi after the network-monitor contract",
             DBUS_TIMEOUT,
-            nm.wait_for_wifi_ready(),
+            async {
+                loop {
+                    match nm.wait_for_wifi_ready().await {
+                        Ok(()) => break,
+                        Err(_) => sleep(Duration::from_millis(100)).await,
+                    }
+                }
+            },
         )
-        .await
-        .expect("the WiFi device did not recover after re-enabling it");
+        .await;
         bounded(
             "rescan after the network-monitor contract",
             DBUS_TIMEOUT,


### PR DESCRIPTION
both attributes said 3.6.0 but the methods were deprecated in 3.5.1.

also fixes some bugs surfaced in the integration tests.