### PR TITLE
fix: skip unreadable profiles in saved-connection lookup

### DIFF
--- a/nmrs/CHANGELOG.md
+++ b/nmrs/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the `nmrs` crate will be documented in this file.
 ### Fixed
 - `#[deprecated(since = ...)]` on `connect_vpn_by_uuid()` and `disconnect_vpn_by_uuid()` said `3.6.0`; corrected to `3.5.1`, the release that actually deprecated them.([#544](https://github.com/freedesktop-rs/nmrs/pull/544))
 - `disconnect()` no longer fails with `org.freedesktop.NetworkManager.Device.NotActive` when the device finishes deactivating between the state check and the `Disconnect` call. The error is treated as already-disconnected and the call still waits for the device to settle. ([#544](https://github.com/freedesktop-rs/nmrs/pull/544))
+- Saved-profile lookups (`get_saved_connection_path()`, `get_saved_connection_uuid()`, `has_saved_connection()`, and the Wi-Fi/wired/VPN/Bluetooth connect paths built on them) no longer fail when a profile restricted to another user via `connection.permissions` exists. `GetSettings` returns `Settings.PermissionDenied` for those; they are now skipped instead of aborting the whole scan, which previously made known networks prompt for a password and then fail to connect. ([#545](https://github.com/freedesktop-rs/nmrs/pull/545))
 
 ## [3.5.1] - 2026-09-02
 ### Added

--- a/nmrs/src/core/connection_settings.rs
+++ b/nmrs/src/core/connection_settings.rs
@@ -36,12 +36,20 @@ async fn find_saved_connection_by_name(
     for cpath in conns {
         let cproxy = connection_settings_proxy(conn, cpath.clone()).await?;
 
-        let msg = cproxy.call_method("GetSettings", &()).await.map_err(|e| {
-            ConnectionError::DbusOperation {
-                context: format!("failed to get settings for {}", cpath.as_str()),
-                source: e,
+        // `ListConnections` includes profiles restricted to other users via
+        // `connection.permissions`; `GetSettings` on those fails with
+        // `Settings.PermissionDenied`. Skip them instead of failing the
+        // whole lookup, matching the other profile scans in this crate.
+        let msg = match cproxy.call_method("GetSettings", &()).await {
+            Ok(msg) => msg,
+            Err(e) => {
+                trace!(
+                    "skipping saved connection {}: GetSettings failed: {e}",
+                    cpath.as_str()
+                );
+                continue;
             }
-        })?;
+        };
 
         let body = msg.body();
         let all: HashMap<String, HashMap<String, Value>> = body.deserialize()?;


### PR DESCRIPTION
`saved-profile` lookup aborted when `GetSettings` hit a profile restricted to another user (`Settings.PermissionDenied`). we now skip it, like the other scans. 

Fixes https://github.com/pop-os/cosmic-settings/issues/2184